### PR TITLE
Add RTM Client options to migrate away from deprecated SlackDataStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 # place your Hubot token here, uncomment this line:
 # HUBOT_SLACK_TOKEN=xoxb-
 
+# Migrate away from using deprecated SlackDataStore
+# see: https://github.com/slackapi/node-slack-sdk/wiki/DataStore-v3.x-Migration-Guide
+# (also fixed "Socket URL has expired" error)
+HUBOT_SLACK_RTM_CLIENT_OPTS='{  "dataStore": false, "useRtmConnect": true }'
+
 # don't let Hubot setup an HTTP server
 HUBOT_HELP_DISABLE_HTTP=true
 


### PR DESCRIPTION
Use these rtm client options to migrate away from the deprecated SlackDataStore. It was also the solution to a problem where the bot was unable to connect after a restart occassionally.